### PR TITLE
portlet: Add mw-portlet class to vector menu

### DIFF
--- a/src/portlet.ts
+++ b/src/portlet.ts
@@ -127,7 +127,8 @@ function addPortlet(navigation: string, id: string, text: string, type: string, 
 				navigation = 'mw-panel';
 			}
 			outerNavClass =
-				'vector-menu vector-menu-' + (navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'dropdown' : 'tabs');
+				'mw-portlet vector-menu vector-menu-' +
+				(navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'dropdown' : 'tabs');
 			innerDivClass = 'vector-menu-content';
 			break;
 		case 'modern':


### PR DESCRIPTION
I can't open the menu on Vector skin. But it's fixed by adding "mw-portlet" class to the nav.