### PR TITLE
portlet: add class to vector dropdown

### DIFF
--- a/src/portlet.ts
+++ b/src/portlet.ts
@@ -128,7 +128,7 @@ function addPortlet(navigation: string, id: string, text: string, type: string, 
 			}
 			outerNavClass =
 				'mw-portlet vector-menu vector-menu-' +
-				(navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'dropdown' : 'tabs');
+				(navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'dropdown vector-menu-dropdown-noicon' : 'tabs');
 			innerDivClass = 'vector-menu-content';
 			break;
 		case 'modern':


### PR DESCRIPTION
Vector has changed the portlet HTML (again) and now requires
.vector-menu-dropdown-noicon for the portlet to display properly in
Vector and New Vector.

https://phabricator.wikimedia.org/T290994