### PR TITLE
Require messages be loaded before registerModule

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -45,7 +45,7 @@ export function init() {
 	Twinkle.preModuleInitHooks.push(
 		// Get messages
 		() => {
-			initMessaging();
+			return initMessaging().then(() => {});
 		},
 
 		// Get user config and perform init actions that rely on the config


### PR DESCRIPTION
I use `msg()` in `beforeAddMenu` or TwinkleModule constructor. I found that it sometimes displays the message key. I'm not sure is this patch correct. But it works.