### PR TITLE
portlet.ts: add vector-menu-heading to vector dropdown label

### DIFF
--- a/src/portlet.ts
+++ b/src/portlet.ts
@@ -164,6 +164,7 @@ function addPortlet(navigation: string, id: string, text: string, type: string, 
 
 	if (skin === 'vector') {
 		ul.className = 'vector-menu-content-list';
+		h3.className = 'vector-menu-heading';
 
 		// add invisible checkbox to keep menu open when clicked
 		// similar to the p-cactions ("More") menu


### PR DESCRIPTION
Changes in [T290280](https://phabricator.wikimedia.org/T290280) (ab11cc9adb8124d93659aca6491b36298d5dc27a) broke the
styling for the Vector dropdown menu. Adding .vector-menu-heading is
required now for correct styling. The h3 element is still used for
Timeless compatibility.